### PR TITLE
Adapt boolean runner params

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ training routine (i.e. `runner`) are installed.
 
     2) `job_prefix`: Prefix that precedes all results folders and experiment specific files.
 
-    3) `output_base_dir`: Directory to which all config files and results folders are saved.
+    3) `output_base_dir`: Directory to which all config files and results folders are saved. # TODO: adapt
+    explanation of relevance to runner
 
     4) `runner`: Path to the file that trains your model.
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ training routine (i.e. `runner`) are installed.
 
         8) `scratch`: Amount of local scratch requested per processor core. Corresponds to `bsub -R "rusage[scratch={scratch}]"`.
 
-    2) `job_prefix`: Prefix that precedes all results folders and experiment specific files.
+    2) `job_prefix`: Prefix that precedes all results folders and experiment specific files. Will be appended to
+    `output_base_dir` to create subfolders `job_prefix{ID}` in `output_base_dir` containing all results of run
+    {ID}.
 
-    3) `output_base_dir`: Directory to which all config files and results folders are saved. # TODO: adapt
-    explanation of relevance to runner
+    3) `output_base_dir`: Directory to which all config files and results folders are saved. `output_base_dir`
+    must be an input argument to the runner and should not be repeated in the `runner_parameters`.
 
     4) `runner`: Path to the file that trains your model.
 
@@ -81,7 +83,7 @@ training routine (i.e. `runner`) are installed.
         1) `data`: a list of paths to your data set file or directory (whatever your `runner` accepts as input
         data). **Note:** `runner` has to accept input data via `{runner} --data {data-path}`.
 
-        2) `{parameter_placeholder}`: You can submit as many parameters as your `runner` accepts input arguments (besides `data`). You just have to make sure that `{parameter_placeholder}` matches an input argument of `runner` and the values of `{parameter_placeholder}` are wrapped in a list. Checkout the [config example](./examples/config_example.json) for an illustrative example.
+        2) `{parameter_placeholder}`: You can submit as many parameters as your `runner` accepts input arguments (besides `data`, `output_base_dir`). You just have to make sure that `{parameter_placeholder}` matches an input argument of `runner` and the values of `{parameter_placeholder}` are wrapped in a list. Checkout the [config example](./examples/config_example.json) for an illustrative example.
           1) If the `type()` of the `parameter_placeholder` value is `bool` (see `augment` key in example
           config) `True` corresponds to adding the `--parameter_placeholder` flag (i.e. `python my_runner.py --parameter_placeholder`). `False` corresponds to
           omitting the flag from the `runner` call (i.e. `python my_runner.py`). NOTE: Beware of inverted logic if parser argument uses `action=store_false`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # model-runner
-**model-runner** is a Python-based CLI to submit hyper-parameter optimization (i.e. grid-search) jobs to the [LSF batch system](https://www.bsc.es/support/LSF/old-9.1.1/lsf_programmer/index.htm?batch_programmer_lsf.html~main). model-runner requires a `.json` config as input and validates the content of the config to prevent common errors such as non-existent files or incorrectly formatted LSF batch submissions parameters.
+**model-runner** is a Python-based CLI to submit hyper-parameter optimization (i.e. grid-search) jobs to the 
+[LSF batch system](https://www.bsc.es/support/LSF/old-9.1.1/lsf_programmer/index.htm?batch_programmer_lsf.html~main). 
+model-runner requires a `.json` config as input and validates the content of the config to prevent common errors such 
+as non-existent files or incorrectly formatted LSF batch submissions parameters.
 
 ## Installation
-model-runner was tested on ETH Zurich's EULER cluster (`IBM Spectrum LSF Standard 10.1.0.7`) and may not work on other clusters or lsf versions.
+model-runner was tested on ETH Zurich's EULER cluster (`IBM Spectrum LSF Standard 10.1.0.7`) and may not work on other 
+clusters or lsf versions.
 
 1) clone the repository
 
@@ -50,25 +54,31 @@ training routine (i.e. `runner`) are installed.
     conda activate model-runner
     ```
 
-2) Write your `.json` config file following the [config example](./examples/config_example.json). Our example config `config_example.json` contains the following parameters
+2) Write your `.json` config file following the [config example](./examples/config_example.json). Our example config 
+`config_example.json` contains the following parameters
 
     1) `job_parameters`: Dictionary containing the 
         1) (optional)`gpu_type`: Type of GPU that is accepted by bsub -R "select[gpu_model0=={gpu_type}]". See
-        this [list of accepted GPUs](https://scicomp.ethz.ch/wiki/Getting_started_with_GPUs#Available_GPU_node_types). If not specified, the job will be run on CPU.
+        this [list of accepted GPUs](https://scicomp.ethz.ch/wiki/Getting_started_with_GPUs#Available_GPU_node_types).
+        If not specified, the job will be run on CPU.
 
         2) `logfile_dir`: Path to directory to which lsf output files are saved.
 
         3) `memory`: Amount of memory requested per processor core. Corresponds to `bsub -R "rusage[mem={memory}]"`.
 
-        4) (optional)`ngpus`: Number of GPUs of `gpu_type` requested. Corresponds to `bsub -R "rusage[ngpus_excl_p={ngpus}]"` and requires `gpu_type` to be specified.
+        4) (optional)`ngpus`: Number of GPUs of `gpu_type` requested. Corresponds to 
+        `bsub -R "rusage[ngpus_excl_p={ngpus}]"` and requires `gpu_type` to be specified.
 
         5) njobs_parallel: Number of jobs (i.e. hyper-parameter combinations) the model-runner will submit in parallel.
 
-        6) `processor_cores`: Number of processor cores requested for a single job. Corresponds to `bsub -n {processor_cores}`.
+        6) `processor_cores`: Number of processor cores requested for a single job. Corresponds to 
+        `bsub -n {processor_cores}`.
 
-        7) `run_time`: The time resources on the compute note are reservered for a single job. Corresponds to `bsub -W {run_time}`.
+        7) `run_time`: The time resources on the compute note are reservered for a single job. Corresponds to 
+        `bsub -W {run_time}`.
 
-        8) `scratch`: Amount of local scratch requested per processor core. Corresponds to `bsub -R "rusage[scratch={scratch}]"`.
+        8) `scratch`: Amount of local scratch requested per processor core. Corresponds to 
+        `bsub -R "rusage[scratch={scratch}]"`.
 
     2) `job_prefix`: Prefix that precedes all results folders and experiment specific files. Will be appended to
     `output_base_dir` to create subfolders `job_prefix{ID}` in `output_base_dir` containing all results of run
@@ -84,10 +94,10 @@ training routine (i.e. `runner`) are installed.
         1) `data`: a list of paths to your data set file or directory (whatever your `runner` accepts as input
         data). **Note:** `runner` has to accept input data via `{runner} --data {data-path}`.
 
-        2) `output_base_dir`: a list of paths to which the results of `runner` are saved. **Note** `runner` has
-        to accept the output folder via `{runner} --output_base_dir {output_path}`.
-
-        3) `{parameter_placeholder}`: You can submit as many parameters as your `runner` accepts input arguments (besides `data`, `output_base_dir`). You just have to make sure that `{parameter_placeholder}` matches an input argument of `runner` and the values of `{parameter_placeholder}` are wrapped in a list. Checkout the [config example](./examples/config_example.json) for an illustrative example.
+        2) `{parameter_placeholder}`: You can submit as many parameters as your `runner` accepts input arguments 
+        (besides `data`, `output_base_dir`). You just have to make sure that `{parameter_placeholder}` matches an input 
+        argument of `runner` and the values of `{parameter_placeholder}` are wrapped in a list. Checkout the 
+        [config example](./examples/config_example.json) for an illustrative example.
             1) If the `type()` of the `parameter_placeholder` value is `bool` (see `augment` key in example config)
             `True` corresponds to adding the `--parameter_placeholder` flag (i.e. `python my_runner.py
             --parameter_placeholder`). `False` corresponds to omitting the flag from the `runner` call (i.e. `python

--- a/README.md
+++ b/README.md
@@ -79,14 +79,19 @@ training routine (i.e. `runner`) are installed.
 
     4) `runner`: Path to the file that trains your model.
 
-    5) `runner_parameters`: Dictionary containing the parameters grid submitted to the runner.
+    5) `runner_parameters`: Dictionary containing the parameters grid submitted to the runner. All values of the
+    dictionary are of type `list()`, including `data` and `output_base_dir`.
         1) `data`: a list of paths to your data set file or directory (whatever your `runner` accepts as input
         data). **Note:** `runner` has to accept input data via `{runner} --data {data-path}`.
 
-        2) `{parameter_placeholder}`: You can submit as many parameters as your `runner` accepts input arguments (besides `data`, `output_base_dir`). You just have to make sure that `{parameter_placeholder}` matches an input argument of `runner` and the values of `{parameter_placeholder}` are wrapped in a list. Checkout the [config example](./examples/config_example.json) for an illustrative example.
-          1) If the `type()` of the `parameter_placeholder` value is `bool` (see `augment` key in example
-          config) `True` corresponds to adding the `--parameter_placeholder` flag (i.e. `python my_runner.py --parameter_placeholder`). `False` corresponds to
-          omitting the flag from the `runner` call (i.e. `python my_runner.py`). NOTE: Beware of inverted logic if parser argument uses `action=store_false`.
+        2) `output_base_dir`: a list of paths to which the results of `runner` are saved. **Note** `runner` has
+        to accept the output folder via `{runner} --output_base_dir {output_path}`.
+
+        3) `{parameter_placeholder}`: You can submit as many parameters as your `runner` accepts input arguments (besides `data`, `output_base_dir`). You just have to make sure that `{parameter_placeholder}` matches an input argument of `runner` and the values of `{parameter_placeholder}` are wrapped in a list. Checkout the [config example](./examples/config_example.json) for an illustrative example.
+            1) If the `type()` of the `parameter_placeholder` value is `bool` (see `augment` key in example config)
+            `True` corresponds to adding the `--parameter_placeholder` flag (i.e. `python my_runner.py
+            --parameter_placeholder`). `False` corresponds to omitting the flag from the `runner` call (i.e. `python
+            my_runner.py`). NOTE: Beware of inverted logic if parser argument uses `action=store_false`.
 
 3) Submit the hyper-parameter optimization
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ model-runner was tested on ETH Zurich's EULER cluster (`IBM Spectrum LSF Standar
     conda create -n model-runner python=3.8
     ```
 
-4) Activate your virtual environment, after your it has been created.
+4) Activate your virtual environment, after it has been created. NOTE: Make sure the dependencies for your
+training routine (i.e. `runner`) are installed.
 
     ```bash
     conda activate model-runner
@@ -79,7 +80,10 @@ model-runner was tested on ETH Zurich's EULER cluster (`IBM Spectrum LSF Standar
         1) `data`: a list of paths to your data set file or directory (whatever your `runner` accepts as input
         data). **Note:** `runner` has to accept input data via `{runner} --data {data-path}`.
 
-        2) `{parameter_placeholder1}`: You can submit as many parameters as your `runner` accepts input arguments (besides `data`). You just have to make sure that `{parameter_placeholder1}` matches an input argument of `runner` and the values of `{parameter_placeholder1}` are wrapped in a list. Checkout the [config example](./examples/config_example.json) for an illustrative example.
+        2) `{parameter_placeholder}`: You can submit as many parameters as your `runner` accepts input arguments (besides `data`). You just have to make sure that `{parameter_placeholder}` matches an input argument of `runner` and the values of `{parameter_placeholder}` are wrapped in a list. Checkout the [config example](./examples/config_example.json) for an illustrative example.
+          1) If the `type()` of the `parameter_placeholder` value is `bool` (see `augment` key in example
+          config) `True` corresponds to adding the `--parameter_placeholder` flag (i.e. `python my_runner.py --parameter_placeholder`). `False` corresponds to
+          omitting the flag from the `runner` call (i.e. `python my_runner.py`). NOTE: Beware of inverted logic if parser argument uses `action=store_false`.
 
 3) Submit the hyper-parameter optimization
 

--- a/model_runner/dispatcher/_tests/test_dispatcher_utils.py
+++ b/model_runner/dispatcher/_tests/test_dispatcher_utils.py
@@ -6,6 +6,9 @@ from model_runner.dispatcher.dispatcher_utils import create_run_command
 def test_create_run_command():
     params = {
         "runner": "test.py",
+        "job_index": 1,
+        "job_prefix": "my_experiment",
+        "output_base_dir": "/some/output/",
         "data": "path_to_data",
         "batch_size": 1,
         "learning_rate": 0.01,
@@ -14,7 +17,7 @@ def test_create_run_command():
     }
     run_command = create_run_command(params)
 
-    expected_command = "python test.py --data path_to_data --batch_size 1 --learning_rate 0.01 --augment"
+    expected_command = "python test.py --data path_to_data --batch_size 1 --learning_rate 0.01 --augment --output_base_dir /some/output/my_experiment1/"
     assert run_command == expected_command
 
 

--- a/model_runner/dispatcher/_tests/test_dispatcher_utils.py
+++ b/model_runner/dispatcher/_tests/test_dispatcher_utils.py
@@ -9,12 +9,12 @@ def test_create_run_command():
         "data": "path_to_data",
         "batch_size": 1,
         "learning_rate": 0.01,
+        "augment": True,
+        "preprocess": False,
     }
     run_command = create_run_command(params)
 
-    expected_command = (
-        "python test.py --data path_to_data --batch_size 1 --learning_rate 0.01"
-    )
+    expected_command = "python test.py --data path_to_data --batch_size 1 --learning_rate 0.01 --augment"
     assert run_command == expected_command
 
 

--- a/model_runner/dispatcher/dispatcher_utils.py
+++ b/model_runner/dispatcher/dispatcher_utils.py
@@ -27,6 +27,12 @@ def create_run_command(params: Dict[str, Any]) -> str:
     job_command = f"python {runner}"
 
     for k, v in params.items():
-        job_command += f" --{k} {v}"
+        if type(v) == bool:
+            if v is True:
+                job_command += f" --{k}"
+            else:
+                pass
+        else:
+            job_command += f" --{k} {v}"
 
     return job_command

--- a/model_runner/dispatcher/dispatcher_utils.py
+++ b/model_runner/dispatcher/dispatcher_utils.py
@@ -24,7 +24,32 @@ def create_run_command(params: Dict[str, Any]) -> str:
     except AssertionError:
         raise TypeError("runner should be a string")
 
+    try:
+        output_base_dir = params.pop("output_base_dir")
+        assert isinstance(output_base_dir, str)
+    except KeyError:
+        raise KeyError("params must contain the key 'output_base_dir'")
+    except AssertionError:
+        raise TypeError("'output_base_dir' should be a string")
+
+    try:
+        job_index = params.pop("job_index")
+        assert isinstance(job_index, int)
+    except KeyError:
+        raise KeyError("params must contain the key 'job_index'")
+    except AssertionError:
+        raise TypeError("'job_index' should be a string")
+
+    try:
+        job_prefix = params.pop("job_prefix")
+        assert isinstance(job_prefix, str)
+    except KeyError:
+        raise KeyError("params must contain the key 'job_prefix'")
+    except AssertionError:
+        raise TypeError("'job_prefix' should be a string")
+
     job_command = f"python {runner}"
+    params["output_base_dir"] = f"{output_base_dir}{job_prefix}{job_index}/"
 
     for k, v in params.items():
         if type(v) == bool:


### PR DESCRIPTION
Currently `bool` `runner_parameters` are handled in a non-conventional way:

`config['runner_parameters']['augment'] = [True]` will be submitted as `python runner.py --augment True` and `config['runner_parameters']['augment'] = [False]` will be submitted as `python runner.py --augment False`

. This PR changes the dispatch format to:

`config['runner_parameters']['augment'] = [True]` will be submitted as `python runner.py --augment` and 
`config['runner_parameters']['augment'] = [False]` will be submitted as `python runner.py`